### PR TITLE
GrossSlimes and A Fast Skelly Breed to Gimmel

### DIFF
--- a/civcraftConfigs/gimmelconfig.yml
+++ b/civcraftConfigs/gimmelconfig.yml
@@ -45,7 +45,7 @@ monster:
      identifier: skeletonFast
 #     name: Bruce Edwards Ivins
      spawn_chance: 0.1
-     health: 2
+     health: 12
      minimum_light_level: 0
      maximum_light_level: 4
      helmet_dropchance: 0
@@ -92,27 +92,6 @@ monster:
      spawn_chance: 0.0666
      identifier: spiders
      maximum_light_level: 7
-   GrossSlimes:
-     type: SLIME
-     spawn_chance: 0.025
-     identifier: GrossSlimes
-     alternative_version: false
-     despawn_on_chunk_unload: false
-     maximum_light_level: 15
-     y_spawn_range: 8
-     on_hit_debuffs:
-      Sticky:
-       type: SLOW
-       level: 2
-       duration: 2s
-       chance: 1.0 
-      GrossSlime:
-       type: POISON
-       level: 15
-       duration: 5s
-       chance: 0.25
-     blocks_to_spawn_on:
-      - GRASS
    creepers:
      type: CREEPER 
      spawn_chance: 0.0222

--- a/civcraftConfigs/gimmelconfig.yml
+++ b/civcraftConfigs/gimmelconfig.yml
@@ -40,11 +40,79 @@ monster:
      spawn_chance: 0.0666
      identifier: skeleton
      maximum_light_level: 7
+   GlassSkulls:
+     type: SKELETON
+     identifier: skeletonFast
+#     name: Bruce Edwards Ivins
+     spawn_chance: 0.1
+     health: 2
+     minimum_light_level: 0
+     maximum_light_level: 4
+     helmet_dropchance: 0
+     chestplate_dropchance: 0
+     leggins_dropchance: 0
+     boots_dropchance: 0
+     item_in_dropchance: 0.2
+     despawn_on_chunk_unload: false
+     can_pickup_items: false
+     y_spawn_range: 16
+     alternative_version: false
+     drops:
+      Bone:
+       material: BONE
+       amount: 2
+     equipment:
+      sharpBone:
+       material: BONE
+       enchants:
+        S1:
+         enchant: DAMAGE_ALL
+         level: 1
+      ArrowChainChest3:
+       material: CHAINMAIL_CHESTPLATE
+       enchants:
+        Arrow2:
+         enchant: PROTECTION_PROJECTILE
+         level: 3
+      buffs:
+       CantDrown:
+        type: WATER_BREATHING
+        level: 2
+       FastBone:
+        type: SPEED
+        level: 2
+     on_hit_debuffs:
+      amthrax:
+       type: POISON
+       level: 2
+       duration: 5s
+       chance: 1.0 
    spiders:
      type: SPIDER 
      spawn_chance: 0.0666
      identifier: spiders
      maximum_light_level: 7
+   GrossSlimes:
+     type: SLIME
+     spawn_chance: 0.025
+     identifier: GrossSlimes
+     alternative_version: false
+     despawn_on_chunk_unload: false
+     maximum_light_level: 15
+     y_spawn_range: 8
+     on_hit_debuffs:
+      Sticky:
+       type: SLOW
+       level: 2
+       duration: 2s
+       chance: 1.0 
+      GrossSlime:
+       type: POISON
+       level: 15
+       duration: 5s
+       chance: 0.25
+     blocks_to_spawn_on:
+      - GRASS
    creepers:
      type: CREEPER 
      spawn_chance: 0.0222


### PR DESCRIPTION
The two new mobs to spawn are slimes and skellies. However, these skeletons are fast, equipped with sharp poison II bones, and are extremely weak. They are like glass knives that cut deep but break easily. Also, they only spawn if the light level is 4 or below, so you would have to be in moonlight or sheltered from light to see them spawn.

As for the slimes, they spawn rarely and give you debuffs if they hit you. Stickiness (slowing you down with Slowness II) is assured, and poison from the gross slime is possible next.

Both mobs are placed into Gimmel's plains. Still, perhaps slimes aren't supposed to be introduced yet, but players have wanted some slimes for quite a while.
