### PR TITLE
DarkJesus Collab to Further Buff Fire Watch in Aleph

### DIFF
--- a/civcraftConfigs/alephconfig.yml
+++ b/civcraftConfigs/alephconfig.yml
@@ -163,12 +163,19 @@ monster:
       fireBoots154:
        material: LEATHER_BOOTS
        enchants:
+        FeatherFall4:
+         enchant: PROTECTION_FALL
+         level: 4
         Prot451:
          enchant: PROTECTION_FIRE
          level: 451
-# Testing if the skelly can wear a black dyed glass head.
-     glasshelm:
-       material: GLASS;0
+# Skeleton's cannot wear glass. Put a leather helmet on instead
+      exglasshelm:
+       material: LEATHER_HELMET
+       enchants:
+        Prot451:
+         enchant: PROTECTION_FIRE
+         level: 451
      buffs:
       CantDrown:
        type: WATER_BREATHING
@@ -205,9 +212,7 @@ monster:
      health: 320
      chestplate_dropchance: 0.02
      leggins_dropchance: 0.02
-     boots_dropchance: 0.01
-     item_in_dropchance: 0
+     boots_dropchance: 0.02
      helmet_dropchance: 0.02
      despawn_on_chunk_unload: true
-     can_pickup_items: false
      y_spawn_range: 16

--- a/civcraftConfigs/alephconfig.yml
+++ b/civcraftConfigs/alephconfig.yml
@@ -126,7 +126,7 @@ monster:
    OPskeletons:
      identifier: firewatchskelly
      type: SKELETON
-     name: RabidFireWatch
+     name: §kFive §4RabidFireWatch §kFive 
      on_hit_message: YOU KILLED MY BIRCH. YOU BETTER RUN
      spawn_chance: 0.44
      drops:
@@ -139,27 +139,39 @@ monster:
          enchant: KNOCKBACK
          level: 1
      equipment:
-      watch:
-       material: WATCH
+      BluntHotRod:
+       material: BLAZE_ROD
        enchants:
-        KB5:
+        KB8:
          enchant: KNOCKBACK
-         level: 5
+         level: 8
         S2:
          enchant: DAMAGE_ALL
          level: 2
       firechest451:
-       material: DIAMOND_CHESTPLATE
+       material: LEATHER_CHESTPLATE
        enchants:
         Prot451:
          enchant: PROTECTION_FIRE
          level: 451
-      fireBoots:
+      firelegs451:
+       material: LEATHER_LEGGINGS
+       enchants:
+        Prot451:
+         enchant: PROTECTION_FIRE
+         level: 451
+      fireBoots154:
        material: LEATHER_BOOTS
        enchants:
         FeatherFall4:
          enchant: PROTECTION_FALL
-         level: 4
+         level: 3
+        Prot451:
+         enchant: PROTECTION_FIRE
+         level: 451
+# Testing if the skelly can wear a black dyed glass head.
+     glasshelm:
+       material: GLASS;0
      buffs:
       CantDrown:
        type: WATER_BREATHING
@@ -173,17 +185,32 @@ monster:
        level: 1
        duration: 1s
        chance: 1.0 
+      blinded:
+       type: BLINDNESS
+       level: 1
+       duration: 1s
+       chance: 1.0 
+      withered:
+       type: WITHER
+       level: 1
+       duration: 2s
+       chance: 1.0 
      blocks_to_spawn_on:
       - STONE
       - DIRT
       - GRASS
       - STATIONARY_LAVA
+      - STATIONARY_WATER 
      blocks_to_spawn_in:
       - AIR
-      - WATER
       - STATIONARY_LAVA
+      - STATIONARY_WATER 
      health: 320
-     chestplate_dropchance: 0.04
+     chestplate_dropchance: 0.02
+     leggins_dropchance: 0.02
+     boots_dropchance: 0.01
+     item_in_dropchance: 0
+     helmet_dropchance: 0.02
      despawn_on_chunk_unload: true
      can_pickup_items: false
      y_spawn_range: 16

--- a/civcraftConfigs/alephconfig.yml
+++ b/civcraftConfigs/alephconfig.yml
@@ -163,9 +163,6 @@ monster:
       fireBoots154:
        material: LEATHER_BOOTS
        enchants:
-        FeatherFall4:
-         enchant: PROTECTION_FALL
-         level: 3
         Prot451:
          enchant: PROTECTION_FIRE
          level: 451


### PR DESCRIPTION
We replaced the diamond chestplate with leather, and the skelly is all leather armor now to reflect the lore of an ancient forest watch that is annoyed with birch forest destruction. The skelly now carries a powerful blaze rod that has knockback 8, sharpness 2. In addition, a hit by this item now induces blindness and wither effects.

Also, it's important to note that this skelly is wearing a black glass head. We are not sure if that line of code to add a glass head will work, but if it does not, then get rid of the glass head. If it works, then we have skellies with black glass heads.

In addition, this mob's name is formatted with Minecraft formating http://minecraft.gamepedia.com/Formatting_codes If these fail to work on the config, let us know.
