### PR TITLE
DJ Collab to add Iron Golem and special witches to Bet

### DIFF
--- a/civcraftConfigs/betconfig.yml
+++ b/civcraftConfigs/betconfig.yml
@@ -157,7 +157,7 @@ monster:
      spawn_chance: 0.0111
      identifier: enderman
      maximum_light_level: 7
-  Iceplains:
+ Iceplains:
   updatetime: 1m
   areas:
     biomes:
@@ -221,39 +221,3 @@ monster:
      despawn_on_chunk_unload: true
      can_pickup_items: false
      y_spawn_range: 16
-
-spawner:
- GhostWitchesOfNSR:
-  updatetime: 1m
-  areas:
-   locations:
-    NSR:
-     Shape: CIRCLE
-     xsize: 50
-     center:
-       x: 400
-       z: 390
-  mobs:
-   GhostWitch:
-    identifier: FloatingWitch
-    spawn: WITCH
-    type: WITCH
-    name: §oOl' Sally
-    range: 32
-    amount: 1
-    maximum_spawn_attempts: 10
-    spawn_chance: 0.4
-    drops:
-     Newfriendlives:
-      material: NETHER_WARTS
-      amount: 20
-      lore: The Great War's Souls
-    buffs:
-     Ghosty:
-      type: INVISIBILITY
-     Slow2:
-      type: SLOW
-      level: 2
-    y_spawn_range: 8
-    minimum_light_level: 0
-    maximum_light_level: 4

--- a/civcraftConfigs/betconfig.yml
+++ b/civcraftConfigs/betconfig.yml
@@ -221,6 +221,6 @@ monster:
       - STATIONARY_LAVA
       - STATIONARY_WATER 
      health: 3000
-     despawn_on_chunk_unload: false
+     despawn_on_chunk_unload: true
      can_pickup_items: false
      y_spawn_range: 16

--- a/civcraftConfigs/betconfig.yml
+++ b/civcraftConfigs/betconfig.yml
@@ -172,10 +172,13 @@ monster:
      on_hit_message: Git Rekt Son
      spawn_chance: 0.1
      drops:
+      pistonwithstickyoil:
+       material: PISTON_STICKY_BASE
+       amount: 2
       DasRekker:
        material: WOOD_SWORD 
        amount: 1
-       chance: 0.01
+       chance: 0.1
        lore: Das Rekker Wood Sword
        enchants:
         FA2:
@@ -218,6 +221,6 @@ monster:
       - STATIONARY_LAVA
       - STATIONARY_WATER 
      health: 3000
-     despawn_on_chunk_unload: true
+     despawn_on_chunk_unload: false
      can_pickup_items: false
      y_spawn_range: 16

--- a/civcraftConfigs/betconfig.yml
+++ b/civcraftConfigs/betconfig.yml
@@ -157,3 +157,103 @@ monster:
      spawn_chance: 0.0111
      identifier: enderman
      maximum_light_level: 7
+  Iceplains:
+  updatetime: 1m
+  areas:
+    biomes:
+     - ROOFED_FOREST
+     - MEGA_SPRUCE_TAIGA
+     - ICE_PLAINS
+  mobconfig:
+    OPirongolem:
+     identifier: PowerGolem
+     type: IRON_GOLEM
+     name: Power Golem
+     on_hit_message: Git Rekt Son
+     spawn_chance: 0.1
+     drops:
+      DasRekker:
+       material: WOOD_SWORD 
+       amount: 1
+       chance: 0.01
+       lore: Das Rekker Wood Sword
+       enchants:
+        FA2:
+         enchant: FIRE_ASPECT
+         level: 2
+         S2:
+         enchant: DAMAGE_ALL
+         level: 2
+     buffs:
+      s4:
+       type: INCREASE_DAMAGE
+       level: 4
+      Fast4:
+       type: SPEED
+       level: 4
+     on_hit_debuffs:
+      Confused:
+       type: CONFUSION
+       level: 1
+       duration: 10s
+       chance: 1.0 
+      blinded:
+       type: BLINDNESS
+       level: 1
+       duration: 5s
+       chance: 1.0 
+      Slowness:
+       type: SLOW
+       level: 2
+       duration: 5s
+       chance: 1.0 
+     blocks_to_spawn_on:
+      - STONE
+      - DIRT
+      - GRASS
+      - STATIONARY_LAVA
+      - STATIONARY_WATER 
+     blocks_to_spawn_in:
+      - AIR
+      - STATIONARY_LAVA
+      - STATIONARY_WATER 
+     health: 3000
+     despawn_on_chunk_unload: true
+     can_pickup_items: false
+     y_spawn_range: 16
+
+spawner:
+ GhostWitchesOfNSR:
+  updatetime: 1m
+  areas:
+   locations:
+    NSR:
+     Shape: CIRCLE
+     xsize: 50
+     center:
+       x: 400
+       z: 390
+  mobs:
+   GhostWitch:
+    identifier: FloatingWitch
+    spawn: WITCH
+    type: WITCH
+    name: §oOl' Sally
+    range: 32
+    amount: 1
+    maximum_spawn_attempts: 10
+    spawn_chance: 0.4
+    drops:
+     Newfriendlives:
+      material: NETHER_WARTS
+      amount: 20
+      lore: The Great War's Souls
+    buffs:
+     Ghosty:
+      type: INVISIBILITY
+     Slow2:
+      type: SLOW
+      level: 2
+    y_spawn_range: 8
+    minimum_light_level: 0
+    maximum_light_level: 4


### PR DESCRIPTION
Like the previous pull, formatting of the name of the mobs may be interesting for testing the code. Also, the iron golem in this code only has a chance of dropping a fire aspect II sword, and it should not drop any iron. 

Also, there is a witch spawn set over the empty and ruined NSR. It's just a cobble encased town with grief all inside after a great war runined all of its newfriends. They are invisible, slow, and drop newfriend souls (netherwart lore) when they die. This should test if it's possible for witches to spawn in an area defined by a circle.

As for the iron golem, it is tough, and it may be set to create special, valuable ingredients in the future that require many players to kill it. I reccomend not hitting it if you want to live.
