### PR TITLE
DJ Collab: Lots of Proposed Spawn Changes to Zion

### DIFF
--- a/civcraftConfigs/zionconfig.yml
+++ b/civcraftConfigs/zionconfig.yml
@@ -27,8 +27,8 @@ daytime_modifier:
 
 fireball:
  netherFireRain:
- frequency: 1h
- range: 96
+ frequency: 1m
+ range: 16
  areas:
  biomes:
   - HELL
@@ -246,12 +246,11 @@ monster:
       spawn_chance: 0.05
       identifier: magmacube
       despawn_on_chunk_unload: true
-    sinspirit:
+    dangedspirit:
       type: ZOMBIE
       spawn_chance: 0.1
-      identifier: sinspirit
-      name:  Spirit of Sintralin
-      alternative_version: true
+      identifier: dangedspirit
+      name: §dSuccubus
       despawn_on_chunk_unload: true
       maximum_light_level: 15
       drops:
@@ -271,7 +270,7 @@ monster:
                level: 2
                duration: 5s
                chance: 1
-      on_hit_message: HCF 4 LIFE
+      on_hit_message: Your strength is very tasty
       blocks_to_spawn_on:
          - NETHERRACK
          - OBSIDIAN

--- a/civcraftConfigs/zionconfig.yml
+++ b/civcraftConfigs/zionconfig.yml
@@ -1,5 +1,8 @@
 worldname: Zion
 cancel_natural_spawns: true
+disable_fireball_terraindamage: true
+disable_fireball_terrainignition: true
+firespread_disabled: true
 
 weathermachines:
   global:
@@ -22,31 +25,43 @@ daytime_modifier:
       biomes:
        - GLOBAL
 
+fireball:
+ netherFireRain:
+ frequency: 1h
+ range: 96
+ areas:
+ biomes:
+  - HELL
+ player_environment_state:
+  night: false
+
 monster:
  normalsection:
-  updatetime: 1m
+  updatetime: 10s
   areas:
     biomes: 
      - EXTREME_HILLS
   mobconfig:
     zombies:
       type: ZOMBIE
-      spawn_chance: 0.0666      
+      spawn_chance: 0.1     
       identifier: zombie
       maximum_light_level: 7
+      despawn_on_chunk_unload: true
     whitewalkers:
       type: ZOMBIE
       identifier: White Walker
-      name: White Walker 
-      spawn_chance: 0.0444
+      name: §1White §1Walker 
+      spawn_chance: 0.2
       amount: 2
       maximum_light_level: 7
+      despawn_on_chunk_unload: true
       equipment:
         sword:
           material: IRON_SWORD
           enchants:
            P2:
-             enchant: SWORD_DAMAGE
+             enchant: DAMAGE_ALL
              level: 1
         ironchest:
            material: IRON_CHESTPLATE
@@ -67,22 +82,30 @@ monster:
       on_hit_message: Your body feels colder
       blocks_to_spawn_on:
          - SNOW
+         - GRASS
+         - DIRT
+      blocks_to_spawn_in:
+         - SNOW
+         - AIR
     skeletons:
       type: SKELETON
-      spawn_chance: 0.0666
+      spawn_chance: 0.1
       identifier: skeleton
       maximum_light_level: 7
+      despawn_on_chunk_unload: true
     spiders:
       type: SPIDER 
       spawn_chance: 0.0666
       identifier: spiders
       maximum_light_level: 7
+      despawn_on_chunk_unload: true
     icespiders:
       type: SPIDER 
-      spawn_chance: 0.07
+      spawn_chance: 0.2
       identifier: icespiders
       maximum_light_level: 7
-      name: Ice Spider
+      despawn_on_chunk_unload: true
+      name: §1Ice §1Spider
       on_hit_debuffs:
          coldtouch:
            type: SLOW
@@ -95,16 +118,19 @@ monster:
       spawn_chance: 0.0222
       identifier: creeper
       maximum_light_level: 7
+      despawn_on_chunk_unload: true
     witches:
       type: WITCH
       spawn_chance: 0.0666
       identifier: witch
       maximum_light_level: 7
+      despawn_on_chunk_unload: true
     enderman:
       type: ENDERMAN
       spawn_chance: 0.0111
       identifier: enderman
       maximum_light_level: 7
+      despawn_on_chunk_unload: true
     chicken:
       type: CHICKEN
       spawn_chance: 0.1
@@ -122,19 +148,21 @@ monster:
       minimum_light_level: 8
         
  ocean:
-  updatetime: 30s
+  updatetime: 15s
   areas:
     biomes:
      - HELL
   mobconfig:
     blaze:
       type: BLAZE
-      spawn_chance: 0.1
+      spawn_chance: 0.05
       identifier: blazes
+      despawn_on_chunk_unload: true
     pigman:
       type: PIG_ZOMBIE
       spawn_chance: 0.2
       identifier: pigman
+      despawn_on_chunk_unload: true
       equipment:
         sword:
           material: GOLD_SWORD
@@ -144,9 +172,108 @@ monster:
                   level: 1
     ghast:
       type: GHAST
-      spawn_chance: 0.1
+      spawn_chance: 0.05
       identifier: ghast
+      despawn_on_chunk_unload: true
+    witherskeletons:
+      type: SKELETON
+      spawn_chance: 0.1
+      identifier: witherskeleton
+      name: §8Big §8Bones
+      alternative_version: true
+      despawn_on_chunk_unload: true
+      maximum_light_level: 11
+      drops:
+       firebones:
+        material: BONE
+        amount: 1
+        lore: Ouch! That is Hot!
+        enchants:
+         F1:
+          enchant: FIRE_ASPECT
+          level: 1
+      equipment:
+        ironboots:
+           material: IRON_BOOTS
+           enchants:
+             Prot2:
+               enchant: PROTECTION_ENVIRONMENTAL
+               level: 2
+        ironchest:
+           material: IRON_LEGGINGS
+           enchants:
+             Prot2:
+               enchant: PROTECTION_ENVIRONMENTAL
+               level: 2
+        ironhelm:
+           material: IRON_HELMET 
+           enchants:
+             Prot2:
+               enchant: PROTECTION_ENVIRONMENTAL
+               level: 2
+        sword:
+          material: IRON_SWORD
+          enchants:
+           burning:
+             enchant: FIRE_ASPECT
+             level: 1
+           S2:
+             enchant: DAMAGE_ALL
+             level: 2
+        ironchest:
+           material: IRON_CHESTPLATE
+           enchants:
+             Prot2:
+               enchant: PROTECTION_ENVIRONMENTAL
+               level: 2
+      buffs:
+        fireres:
+               type: FIRE_RESISTANCE
+               level: 1
+      on_hit_debuffs:
+        burningtouch:
+               type: WEAKNESS
+               level: 1
+               duration: 5s
+               chance: 1
+      on_hit_message: Your body burns
+      blocks_to_spawn_on:
+         - NETHERRACK
+         - OBSIDIAN
+         - STATIONARY_LAVA
     magmacube:
       type: MAGMA_CUBE
-      spawn_chance: 0.1
+      spawn_chance: 0.05
       identifier: magmacube
+      despawn_on_chunk_unload: true
+    sinspirit:
+      type: ZOMBIE
+      spawn_chance: 0.1
+      identifier: sinspirit
+      name:  Spirit of Sintralin
+      alternative_version: true
+      despawn_on_chunk_unload: true
+      maximum_light_level: 15
+      drops:
+       Cane:
+        material: SUGAR_CANE 
+        amount: 4
+      buffs:
+        fireres:
+               type: FIRE_RESISTANCE
+               level: 1
+        res:
+               type: RESISTANCE
+               level: 1
+      on_hit_debuffs:
+        burningtouch:
+               type: WEAKNESS
+               level: 2
+               duration: 5s
+               chance: 1
+      on_hit_message: HCF 4 LIFE
+      blocks_to_spawn_on:
+         - NETHERRACK
+         - OBSIDIAN
+         - STATIONARY_LAVA
+      health: 100


### PR DESCRIPTION
To keep with the lore of how hellish the Hell biome and surrounding areas is.

DarkJesus implemented fire rain. We hope it works once per hour (or more in the future). The fireballs spawn within 96 meters of the player, too. The fireballs should not destroy terrain or set new fires, too.

Mob spawning on the extreme hills has been buffed. Due to how the config once had a 1 minute spawn time instead of 15 seconds like other shards, it is no wonder why we never saw mobs in the extreme hills! Mobs were far too unlikely to spawn. Also, due to Zion's limited capacity, mobs are set to despawn upon the player unloading the chunk. 

We also asked for custom mobs on the subreddit. Only the Spirit of Sintralin made the list, and it makes sense that a banned player would be nothing more than a zombie in Zion's Hell.

Also, we changed some spawn configs of your White Walker zombie. It feels obvious that it was not spawning because they needed to spawn in snow AND in air. We'll see if they spawn this time.

Also, added an amored wither skelly that drops only a fire aspect bone. Possibly going to make it harder. 

Hopefully, the hell biome is more challenging as it should be for being hell. More buffing may come.
