### PR TITLE
Dark Jesus Collab, Adding Gimmel Mobs

### DIFF
--- a/civcraftConfigs/gimmelconfig.yml
+++ b/civcraftConfigs/gimmelconfig.yml
@@ -253,8 +253,8 @@ monster:
         Prot2:
          enchant: PROTECTION_ENVIRONMENTAL
          level: 2
-      skullhelm2:
-       material: SKULL
+      leatherhelm2:
+       material: CHAINMAIL_HELMET
        enchants:
         Prot2:
          enchant: PROTECTION_ENVIRONMENTAL
@@ -277,7 +277,7 @@ monster:
        level: 1
        duration: 2s
        chance: 1.0 
-     nightv:
+      nightv:
        type: NIGHT_VISION
        level: 1
        duration: 30s
@@ -373,39 +373,3 @@ monster:
       - DIRT
       - GRASS
       - SAND
-
-spawner:
- GhostWitchesOfAquila:
-  updatetime: 2m
-  areas:
-   locations:
-    Aquila:
-     Shape: CIRCLE
-     xsize: 100
-     center:
-       x: 1000
-       z: 64
-  mobs:
-   GhostWitch:
-    identifier: FloatingWitch2
-    spawn: WITCH
-    type: WITCH
-    name: §oOl' §oSally
-    range: 32
-    amount: 1
-    maximum_spawn_attempts: 10
-    spawn_chance: 0.4
-    drops:
-     Newfriendlives:
-      material: NETHER_WARTS
-      amount: 10
-      lore: The Great War's Souls
-    buffs:
-     Ghosty:
-      type: INVISIBILITY
-     Slow2:
-      type: SLOW
-      level: 2
-    y_spawn_range: 8
-    minimum_light_level: 0
-    maximum_light_level: 5

--- a/civcraftConfigs/gimmelconfig.yml
+++ b/civcraftConfigs/gimmelconfig.yml
@@ -74,7 +74,7 @@ monster:
         type: SPEED
         level: 2
      on_hit_debuffs:
-      amthrax:
+      anthrax:
        type: POISON
        level: 2
        duration: 5s
@@ -153,16 +153,159 @@ monster:
      blocks_to_spawn_in:
       - WATER
       - STATIONARY_WATER
+   dirtyspider:
+     identifier: dirtyspider
+     type: CAVE_SPIDER
+     name: Dirty Spider
+     on_hit_message: Cant Catch Me
+     spawn_chance: 0.01
+     drops:
+      String:
+       material: STRING 
+       amount: 16
+       chance: 1
+      spidereyes:
+       material: SPIDER_EYE 
+       amount: 8
+       chance: 1
+      fermspidereyes:
+       material: FERMENTED_SPIDER_EYE  
+       amount: 4
+       chance: 0.3
+     buffs:
+      Fast2:
+       type: SPEED
+       level: 2
+     on_hit_debuffs:
+      poison:
+       type: POISON
+       level: 1
+       duration: 10s
+       chance: 1.0 
+      blinded:
+       type: BLINDNESS
+       level: 1
+       duration: 5s
+       chance: 1.0 
+      Slowness:
+       type: SLOW
+       level: 2
+       duration: 5s
+       chance: 1.0 
+     blocks_to_spawn_on:
+      - STONE
+      - DIRT
+      - GRASS
+      - STATIONARY_LAVA
+      - STATIONARY_WATER 
+     blocks_to_spawn_in:
+      - AIR
+      - STATIONARY_LAVA
+      - STATIONARY_WATER 
+     health: 100
+     despawn_on_chunk_unload: true
+     can_pickup_items: false
+     y_spawn_range: 16
+   darkzombiearcher:
+     identifier: undeadarcher
+     type: ZOMBIE
+     name: Dark Archer
+     on_hit_message:  "**Zombie** **Snarls** **Crunch** **Rawr**"
+     spawn_chance: 0.05
+     drops:
+      Flesh:
+       material: ROTTEN_FLESH
+       amount: 8
+       chance: 1
+      zquiver:
+       material: ARROW
+       amount: 8
+       chance: 1
+       lore: Zombie Quiver
+      pistonwithstickyblood:
+       material: PISTON_STICKY_BASE
+       amount: 2
+     equipment:
+      ZombieArrows:
+       material: BOW 
+       enchants:
+        Punch4:
+         enchant: ARROW_KNOCKBACK
+         level: 4
+        Fire1:
+         enchant: ARROW_FIRE
+         level: 1
+      chainchest2:
+       material: CHAINMAIL_CHESTPLATE
+       enchants:
+        Prot2:
+         enchant: PROTECTION_ENVIRONMENTAL
+         level: 2
+      chainlegs2:
+       material: CHAINMAIL_LEGGINGS
+       enchants:
+        Prot2:
+         enchant: PROTECTION_ENVIRONMENTAL
+         level: 2
+      chainboots2:
+       material: CHAINMAIL_BOOTS
+       enchants:
+        Prot2:
+         enchant: PROTECTION_ENVIRONMENTAL
+         level: 2
+      skullhelm2:
+       material: SKULL
+       enchants:
+        Prot2:
+         enchant: PROTECTION_ENVIRONMENTAL
+         level: 2
+     buffs:
+      Fast2:
+       type: SPEED
+       level: 2
+      Regen3:
+       type: REGENERATION
+       level: 3
+     on_hit_debuffs:
+      confusion:
+       type: CONFUSION
+       level: 1
+       duration: 10s
+       chance: 1.0 
+      blinded:
+       type: BLINDNESS
+       level: 1
+       duration: 2s
+       chance: 1.0 
+     nightv:
+       type: NIGHT_VISION
+       level: 1
+       duration: 30s
+       chance: 1.0 
+     blocks_to_spawn_on:
+      - STONE
+      - DIRT
+      - GRASS
+      - STATIONARY_LAVA
+      - STATIONARY_WATER 
+     blocks_to_spawn_in:
+      - AIR
+      - STATIONARY_LAVA
+      - STATIONARY_WATER 
+     health: 40
+     despawn_on_chunk_unload: true
+     can_pickup_items: false
+     y_spawn_range: 16     
 
  desertsection:
-  updatetime: 1m
+  updatetime: 30s
   areas:
     biomes:
      - DESERT
   mobconfig:
    skeletons:
      type: SKELETON
-     spawn_chance: 0.07    
+     spawn_chance: 0.05    
      identifier: skeleton
      maximum_light_level: 7
    ozymandias:
@@ -213,9 +356,9 @@ monster:
    solarcreepers:
      type: CREEPER 
      spawn_chance: 0.01
-     name: Solar Creeper
+     name: §2Solar §2Creeper
      identifier: solarcreeper
-     maximum_light_level: 7
+     maximum_light_level: 15
      buffs:
           speed2:
                type: SPEED
@@ -229,3 +372,40 @@ monster:
      blocks_to_spawn_on:
       - DIRT
       - GRASS
+      - SAND
+
+spawner:
+ GhostWitchesOfAquila:
+  updatetime: 2m
+  areas:
+   locations:
+    Aquila:
+     Shape: CIRCLE
+     xsize: 100
+     center:
+       x: 1000
+       z: 64
+  mobs:
+   GhostWitch:
+    identifier: FloatingWitch2
+    spawn: WITCH
+    type: WITCH
+    name: §oOl' §oSally
+    range: 32
+    amount: 1
+    maximum_spawn_attempts: 10
+    spawn_chance: 0.4
+    drops:
+     Newfriendlives:
+      material: NETHER_WARTS
+      amount: 10
+      lore: The Great War's Souls
+    buffs:
+     Ghosty:
+      type: INVISIBILITY
+     Slow2:
+      type: SLOW
+      level: 2
+    y_spawn_range: 8
+    minimum_light_level: 0
+    maximum_light_level: 5

--- a/civcraftConfigs/gimmelconfig.yml
+++ b/civcraftConfigs/gimmelconfig.yml
@@ -224,7 +224,7 @@ monster:
        lore: Zombie Quiver
       pistonwithstickyblood:
        material: PISTON_STICKY_BASE
-       amount: 2
+       amount: 1
      equipment:
       ZombieArrows:
        material: BOW 


### PR DESCRIPTION
Changed Amthrax to anthrax in config spelling.

Added two new mobs for the plains biome. Also, added ghost witches to Aquila's location. They are supposed to spawn in town at night, they are slow, and they are invisible. They drop ten netherwarts that are newfriend souls when they die (the lore has no specific purpose for anything useful).

The new mobs are a dirty spider and a dark archer. THe first is a cave spider with some serious speed II, and debuffs like blindness and posion against players. They drop some good loot for how hard they are to kill. As for the dark archer, he drops sticky pistons, but he has regen III, and punch IV with fire I on the bow. The debuffs are blindness and then night vision for the player, and confusion.

The spawn rate in the desert should also buff up, with skellies remaining about the same in that area and other mobs like the solar creeper blowing more stuff up. It has seemed there aren't many mobs at all in the desert.
