### PR TITLE
Dark Jesus Collab Adding Mobs and Buffing in Tet

### DIFF
--- a/civcraftConfigs/tetconfig.yml
+++ b/civcraftConfigs/tetconfig.yml
@@ -31,7 +31,6 @@ daytime_modifier:
     areas:
       biomes:
        - GLOBAL
-
 monster:
  normalsection:
   updatetime: 15s
@@ -65,7 +64,7 @@ monster:
       spawn_chance: 0.01
       name: Drop Creeper
       identifier: dropcreeper
-      maximum_light_level: 7
+      maximum_light_level: 15
       blocks_to_spawn_on:
       - LEAVES
     witches:
@@ -82,31 +81,34 @@ monster:
       type: CHICKEN
       spawn_chance: 0.2
       identifier: chicken
-      minimum_light_level: 8
+      minimum_light_level: 7
       blocks_to_spawn_on:
       - DIRT
       - GRASS
+      - SAND
     horse:
       type: HORSE
       spawn_chance: 0.001
       identifier: horse
-      minimum_light_level: 8
+      minimum_light_level: 7
       blocks_to_spawn_on:
       - DIRT
       - GRASS
+      - SAND
     pig:
       type: PIG
       spawn_chance: 0.05
       identifier: pig
-      minimum_light_level: 8
+      minimum_light_level: 7
       blocks_to_spawn_on:
       - DIRT
       - GRASS
+      - SAND
     rabbit:
       type: RABBIT
       spawn_chance: 0.02
       identifier: rabbit
-      minimum_light_level: 8
+      minimum_light_level: 7
       blocks_to_spawn_on:
       - DIRT
       - GRASS
@@ -114,7 +116,7 @@ monster:
       type: SHEEP
       spawn_chance: 0.04
       identifier: sheep
-      minimum_light_level: 8
+      minimum_light_level: 7
       blocks_to_spawn_on:
       - DIRT
       - GRASS
@@ -122,8 +124,95 @@ monster:
       type: OCELOT
       spawn_chance: 0.05
       identifier: ocelot
-      minimum_light_level: 8
-        
+      minimum_light_level: 7
+    JungleSkelly:
+     identifier: jungleskelly
+     type: SKELETON
+     range: 80
+     amount: 1
+     name: §kFive §2JungleSkelly §kFive 
+     on_hit_message: YOU KILLED MY COCO. PISS OFF M8
+     spawn_chance: 0.2
+     drops:
+      PowBone:
+       material: BONE
+       amount: 2
+       lore: Coco Knocker
+       enchants:
+        KB1:
+         enchant: KNOCKBACK
+         level: 1
+     equipment:
+      BluntHotRod:
+       material: BONE
+       enchants:
+        KB8:
+         enchant: KNOCKBACK
+         level: 8
+        S2:
+         enchant: DAMAGE_ALL
+         level: 2
+      firechest451:
+       material: LEATHER_CHESTPLATE
+       enchants:
+        Prot451:
+         enchant: PROTECTION_FIRE
+         level: 451
+      firelegs451:
+       material: LEATHER_LEGGINGS
+       enchants:
+        Prot451:
+         enchant: PROTECTION_FIRE
+         level: 451
+      fireBoots154:
+       material: LEATHER_BOOTS
+       enchants:
+        FeatherFall4:
+         enchant: PROTECTION_FALL
+         level: 3
+#Warning: Glass helmet may be non functional. Eleminate glass helmet if needed.
+     glasshelm:
+       material: GLASS;0
+     buffs:
+      CantDrown:
+       type: WATER_BREATHING
+       level: 2
+      Fast1:
+       type: SPEED
+       level: 1
+     on_hit_debuffs:
+      RunForestRun:
+       type: SPEED
+       level: 1
+       duration: 1s
+       chance: 1.0 
+      blinded:
+       type: BLINDNESS
+       level: 1
+       duration: 1s
+       chance: 1.0 
+      withered:
+       type: WITHER
+       level: 1
+       duration: 2s
+       chance: 1.0 
+     blocks_to_spawn_on:
+      - STONE
+      - DIRT
+      - GRASS
+      - STATIONARY_LAVA
+      - STATIONARY_WATER 
+      - LEAVES
+      - LEAVES_2
+     blocks_to_spawn_in:
+      - AIR
+      - STATIONARY_LAVA
+      - STATIONARY_WATER 
+     health: 160
+     despawn_on_chunk_unload: true
+     can_pickup_items: false
+     y_spawn_range: 16
+
  ocean:
   updatetime: 10s
   areas:
@@ -138,15 +227,24 @@ monster:
       blocks_to_spawn_in:
        - WATER
        - STATIONARY_WATER
-    guardians:
-      type: GUARDIAN
-      spawn_chance: 0.5
-      identifier: squid
+    squidder:
+      type: SQUID
+      spawn_chance: 0.04
+      identifier: squidder
+      name: Squidder
       blocks_to_spawn_in:
        - WATER
        - STATIONARY_WATER
+    guardians:
+      type: GUARDIAN
+      spawn_chance: 0.5
+      identifier: guardians
+      blocks_to_spawn_in:
+       - WATER
+       - STATIONARY_WATER
+
  volcanos:
-  updatetime: 10s
+  updatetime: 5s
   areas:
     biomes:
      - JUNGLE_HILLS
@@ -164,3 +262,65 @@ monster:
             Renenseanse:
                        type: RESISTANCE
                        level: 1      
+    firespider:
+      type: SPIDER
+      name: Fire Spider
+      spawn_chance: 0.4
+      identifier: firespider
+      on_hit_message: STOP BOTTING AND FITE M8
+      on_hit_debuffs:
+            wither:
+                       type: WITHER
+                       level: 1
+                       duration: 3s
+                       chance: 0.5 
+spawner:
+ zombieloggers:
+  updatetime: 2m
+  areas:
+   locations:
+    BongoBongoLand:
+     Shape: CIRCLE
+     xsize: 180
+     center:
+       x: -860
+       z: 570
+  mobs:
+   darklogger:
+    identifier: zombielogger
+    spawn: ZOMBIE
+    type: ZOMBIE
+    name: §3Paul §3Bunyan
+    range: 32
+    amount: 1
+    maximum_spawn_attempts: 10
+    spawn_chance: 0.45
+    equipment:
+     safetyhat:
+       material: LEATHER_HELMET
+       enchants:
+        prot5:
+         type: PROTECTION_ENVIRONMENTAL
+         level: 5
+     burningaxe:
+      type: WOOD_AXE
+      enchants:
+       burning1:
+        type: FIRE_ASPECT
+        level: 1
+    drops:
+     Newfriendbloodiedaxe:
+      material: WOOD_AXE
+      amount: 1
+      lore: Burning for you
+      enchants:
+       Burning:
+        type: FIRE_ASPECT
+        level: 1
+    buffs:
+     HealthyJack:
+      type: SPEED
+      level: 1
+    y_spawn_range: 16
+    minimum_light_level: 0
+    maximum_light_level: 6

--- a/civcraftConfigs/tetconfig.yml
+++ b/civcraftConfigs/tetconfig.yml
@@ -170,9 +170,7 @@ monster:
         FeatherFall4:
          enchant: PROTECTION_FALL
          level: 3
-#Warning: Glass helmet may be non functional. Eleminate glass helmet if needed.
-     glasshelm:
-       material: GLASS;0
+#No glass helms permitted. Leave it to be whatever helmet wanted.
      buffs:
       CantDrown:
        type: WATER_BREATHING
@@ -274,53 +272,3 @@ monster:
                        level: 1
                        duration: 3s
                        chance: 0.5 
-spawner:
- zombieloggers:
-  updatetime: 2m
-  areas:
-   locations:
-    BongoBongoLand:
-     Shape: CIRCLE
-     xsize: 180
-     center:
-       x: -860
-       z: 570
-  mobs:
-   darklogger:
-    identifier: zombielogger
-    spawn: ZOMBIE
-    type: ZOMBIE
-    name: §3Paul §3Bunyan
-    range: 32
-    amount: 1
-    maximum_spawn_attempts: 10
-    spawn_chance: 0.45
-    equipment:
-     safetyhat:
-       material: LEATHER_HELMET
-       enchants:
-        prot5:
-         type: PROTECTION_ENVIRONMENTAL
-         level: 5
-     burningaxe:
-      type: WOOD_AXE
-      enchants:
-       burning1:
-        type: FIRE_ASPECT
-        level: 1
-    drops:
-     Newfriendbloodiedaxe:
-      material: WOOD_AXE
-      amount: 1
-      lore: Burning for you
-      enchants:
-       Burning:
-        type: FIRE_ASPECT
-        level: 1
-    buffs:
-     HealthyJack:
-      type: SPEED
-      level: 1
-    y_spawn_range: 16
-    minimum_light_level: 0
-    maximum_light_level: 6


### PR DESCRIPTION
Drop Creepers can now spawn any time of day. Truely, I've never seen these mobs while I was in Concordia, so hopefully we see some now.

Jungle skelly added. Has similar powers to the Fire Watch Skelly with the knockback and all, but a third of the health and a larger range for it to spawn (only one should spawn within 80 blocks of a player).

Squidder joke mob for squids added, too, with 4% chance

Minimum light levels for many passive mobs decreased to 7, and they can spawn on sand now, too.

Firespider mob added to buff difficulty of mining obby on the obby islands. 40% chance of spawning, and has a nasty wither bite.

Also, added zombie lumberjacks to the empty, decaying town of BongoBongo. May it rest in peace and hopefully the zombie loggers keep the travelers from tearing down the last of Tet's jungle. (45% chance of spawning per 2 minutes within 32 meters of player.) Also, he drops a fire aspect wood axe and has a speed 1 buff.
