### PR TITLE
Nerfing OPZombie and Dryad in Aleph

### DIFF
--- a/civcraftConfigs/alephconfig.yml
+++ b/civcraftConfigs/alephconfig.yml
@@ -108,7 +108,7 @@ monster:
      type: ZOMBIE
      name: §kFive §4Running §4Ghoul §kFive 
      on_hit_message: Snarl
-     spawn_chance: 0.2
+     spawn_chance: 0.0333
      drops:
       Flesh:
        material: ROTTEN_FLESH
@@ -165,12 +165,7 @@ monster:
        level: 2
       Fast1:
        type: SPEED
-       level: 4
-     on_hit_debuffs:
-      blinded:
-       type: BLINDNESS
-       level: 2
-       duration: 10s
+       level: 1
      blocks_to_spawn_on:
       - STONE
       - DIRT
@@ -187,7 +182,7 @@ monster:
       - AIR
       - STATIONARY_LAVA
       - STATIONARY_WATER 
-     health: 100
+     health: 20
      despawn_on_chunk_unload: true
      y_spawn_range: 16
    treespider:
@@ -257,7 +252,7 @@ monster:
      y_spawn_range: 16
    lorax:
      type: SKELETON
-     spawn_chance: 0.15
+     spawn_chance: 0.0333
      identifier: lorax
      name: §aDryad
      despawn_on_chunk_unload: false


### PR DESCRIPTION
Way too overpowered for OPZombie. Getting rid of the blindness effect on impact with a player, cutting health to 20 from 100, and reducing spawn chance per 15 seconds to 3.33% from 20%, and reducing the zombie's speed buff to level 1 from 4. These were major complaints from players because they could not see after getting hit, and the zombies were too fast and took too many hits to kill. Also, way too many OPzombies relative to other mobs.

Apparently, it was able to kill players who were wearing prot I armor, too.

Dryad (a custom skelly) received no major  complaints, but it was too common relative to the vanilla skeleton spawn rate (a powerful skeleton should not be more common than peasant skeletons). Proposed change is to reduce spawn rate to 3.33% (half of vanilla skelly spawn rate).

Reports of movement halting in Aleph suggest that a single mob like the old OPZombie can make shards overwhelming to live in for even the most geared players. Do with the old, super OPZombie what you will in 3.0 with its hellish shards.

(YAML config changes verfied by YAMLint. No indenting changes made.)
