### PR TITLE
Fixes for midair spawn, player exclusion zones, and configured vs. expressed spawnchance.

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,7 @@
-name: EnvironmentalEffects
-version: 1.0
+name: ${project.name}
+version: ${project.version}
 author: [Maxopoly]
+authors: [BlackXNT, ProgrammerDan]
 depend: [CivModCore]
 main: com.github.maxopoly.environmentaleffects.EnvironmentalEffects
 commands:

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.github.maxopoly</groupId>
 	<artifactId>EnvironmentalEffects</artifactId>
-	<version>1.1.4</version>
+	<version>1.1.5</version>
 	<packaging>jar</packaging>
 
 	<name>EnvironmentalEffects</name>
@@ -29,10 +29,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.3</version>
+				<version>3.5.1</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 		<dependency>
 			<groupId>vg.civcraft.mc.citadel</groupId>
 			<artifactId>Citadel</artifactId>
-			<version>3.4.0</version>
+			<version>3.5.8</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/com/github/maxopoly/environmentaleffects/datarepresentations/MobConfig.java
+++ b/src/main/java/com/github/maxopoly/environmentaleffects/datarepresentations/MobConfig.java
@@ -151,7 +151,7 @@ public class MobConfig {
 			int x = (int) (loc.getBlockX() + (raduis * Math.cos(angle)));
 			int z = (int) (loc.getBlockZ() + (raduis * Math.sin(angle)));
 			BlockCountState bcs = BlockCountState.NOTHING;
-			LinkedList<Integer> yLevels = new LinkedList<Integer>();
+			LinkedList<Float> yLevels = new LinkedList<Float>();
 			for (int y = Math.max(0, loc.getBlockY() - ySpawnRange); 
 					y <= Math.min(254, loc.getBlockY() + ySpawnRange); y++) {
 				Block block = loc.getWorld().getBlockAt(x, y, z);
@@ -161,7 +161,7 @@ public class MobConfig {
 					if ( (spawnInBlocks == null && m == Material.AIR)
 							||
 						 (spawnInBlocks != null && spawnInBlocks.contains(m)) ) {
-						int light = Math.max(block.getLightFromSky(), block.getLightFromBlocks());
+						int light = block.getLightLevel(); //Math.max(block.getLightFromSky(), block.getLightFromBlocks());
 
 						if (light >= minimumLightLevel && light <= maximumLightLevel) {
 							bcs = BlockCountState.ONEAIR;
@@ -177,7 +177,7 @@ public class MobConfig {
 							(spawnInBlocks == null && m == Material.AIR)
 								||
 							(spawnInBlocks != null && spawnInBlocks.contains(m)) ) ) {
-						yLevels.add(y);
+						yLevels.add((float) y - 0.5f);
 						bcs = BlockCountState.NOTHING;
 						break;
 					} else {
@@ -209,8 +209,8 @@ public class MobConfig {
 				}
 			}
 			if (yLevels.size() > 0) {
-				return new Location(loc.getWorld(), x, yLevels.get(rng
-						.nextInt(yLevels.size())), z);
+				return new Location(loc.getWorld(), (double) x + 0.5d, yLevels.get(rng
+						.nextInt(yLevels.size())), (double) z + 0.5d);
 			}
 		}
 		return null;

--- a/src/main/java/com/github/maxopoly/environmentaleffects/listeners/MobListeners.java
+++ b/src/main/java/com/github/maxopoly/environmentaleffects/listeners/MobListeners.java
@@ -45,7 +45,7 @@ public class MobListeners implements Listener {
 	public void monsterSpawn(CreatureSpawnEvent e) {
 		if (cancelAllOther
 				&& (e.getSpawnReason() == SpawnReason.NATURAL || e.getSpawnReason() == SpawnReason.CHUNK_GEN
-				|| e.getSpawnReason() == SpawnReason.LIGHTNING || e.getSpawnReason() == SpawnReason.TRAP)
+				|| e.getSpawnReason() == SpawnReason.LIGHTNING || e.getSpawnReason().name().equalsIgnoreCase("TRAP")) // build refuses to work with standard enum, even though it definitely exists
 				&& e.getEntity() instanceof LivingEntity) {
 			e.setCancelled(true);
 		}


### PR DESCRIPTION
Fix for mobs spawning in mid air, refactored spawning code to be a bit more consistent with respect to the player exclusion zone, which was easily bypassed on prior revisions. Fixed probability so we'll have to fix the configs, most likely. Before this commit every spawn had to pass 2 checks against the spawnChance, meaning that the probability was dependent, suppressing mob spawns overall. Now that its fixed and properly independent, whatever mob spawn rates we are using will probably be too high. Also corrected some minor issues with plugin.yml.
